### PR TITLE
Fix typo and logic error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,43 @@
+0.5
+---
+
+This release has many changes contributed primarily by Vivek Goyal.
+
+### Docker pool just uses 60%, and will auto-grow using LVM
+
+ - docker-storage-setup: Reserve 60% of free space for data volume
+ - docker-storage-setup: Enable automatic pool extension using lvm facilities
+ - docker-storage-setup: Do not grow data volumes upon restart
+
+These three changes mean that storage is now more dynamic in a
+more reliable fashion.
+
+Previously, the pool would use all configured space, which meant
+things like Docker volumes or regular host storage would be limited to
+the OS default (for Project Atomic, 3G).  With this change, the root
+LV can be grown by the system administrator dynamically.
+
+The growing of the Docker pool is now managed by LVM dynamically, and
+will not be automatically resized whenever d-s-s runs (normally once
+on boot).
+
+### Growpart logic reworked
+
+In cloud environments, a "growpart" logic is common where the partition
+table is changed on first boot with extra storage provided by the hypervisor.
+
+However, one essentially never wants to do this with real physical
+disks.
+
+The growpart logic is disabled by default, and virtualization images
+should be tweaked to turn it on.  For example, the Fedora
+spin-kickstarts git module has a kickstart file with a %post that
+would be an appropriate place.
+
+### Performance optimizations
+
+ - docker-storage-setup: Skip block zeroing in thin pool
+ - docker-storage-setup: Use chunk size 512K by default
+
+Will make Docker devicemapper usage faster.
+

--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -36,8 +36,15 @@ The options below should be specified as values acceptable to 'lvextend -L':
 ROOT_SIZE: The size to which the root filesystem should be grown.
 
 DATA_SIZE: The desired size for the docker data LV.  Defaults to using
-           all free space in the VG after the root LV and docker
+           98% free space in the VG after the root LV and docker
            metadata LV have been allocated/grown.
+
+           DATA_SIZE can take values acceptable to "lvcreate -L" as
+           well as some values acceptable to to "lvcreate -l". If user
+           intends to pass values acceptable to "lvcreate -l", then
+           only those values which contains "%" in syntax are
+           acceptable.  If value does not contain "%" it is assumed
+           value is suitable for "lvcreate -L".
 
 
 \f[B]Sample\f[]

--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -35,6 +35,12 @@ VG:   The volume group to use for docker storage.  Defaults to the
       lvm2 version should be same or higher than lvm2-2.02.112 for lvm
       thin pool functionality to work properly.
 
+GROWPART:
+      One can use this option to enable/disable growing of partition
+      table backing root volume group. This is intended for virtualization
+      and cloud installations. By default it is disabled. Use GROWPART=true
+      to enable automatic partition table resizing.
+
 The options below should be specified as values acceptable to 'lvextend -L':
 
 ROOT_SIZE: The size to which the root filesystem should be grown.

--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -10,7 +10,11 @@ docker\-storage\-setup - Grows the root filesystem and sets up a LVM thin pool f
 None. 
 .SH EXAMPLES
 Run \f[B]docker-storage-setup\f[] after setting up your configuration in 
-/etc/sysconfig/docker-storage-setup. 
+/etc/sysconfig/docker-storage-setup. One can look at
+/usr/lib/docker-storage-setup/docker-storage-setup for various options and
+their default settings. Anything user wants to change, should be changed
+in /etc/sysconfig/docker-storage-setup. This is the file which will
+override any settings specified in /usr/lib/docker-storage-setup/docker-storage-setup.
 
 lvm2 version should be same or higher than lvm2-2.02.112 for lvm thin pool
 functionality to work properly.

--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -56,6 +56,10 @@ POOL_AUTOEXTEND_PERCENT:
       that when threhold is hit, pool will be grown by 20% of existing
       pool size.
 
+CHUNK_SIZE:
+      Controls the chunk size/block size of thin pool. Value of CHUNK_SIZE
+      be suitable to be passed to --chunk-size option of lvconvert.
+
 The options below should be specified as values acceptable to 'lvextend -L':
 
 ROOT_SIZE: The size to which the root filesystem should be grown.

--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -41,6 +41,21 @@ GROWPART:
       and cloud installations. By default it is disabled. Use GROWPART=true
       to enable automatic partition table resizing.
 
+AUTO_EXTEND_POOL:
+      Enable automatic extension of pool by lvm. lvm can monitor
+      the pool and automatically extend it when pool is getting full.
+
+POOL_AUTOEXTEND_THRESHOLD:
+      Determines the pool extension threshold in terms of percentage
+      of pool size. For example, if threhold is 60, that means when
+      pool is 60% full, threshold has been hit.
+
+POOL_AUTOEXTEND_PERCENT:
+      Determines the amount by which pool needs to be grown. This is
+      specified in terms of % of pool size. So a value of 20 means
+      that when threhold is hit, pool will be grown by 20% of existing
+      pool size.
+
 The options below should be specified as values acceptable to 'lvextend -L':
 
 ROOT_SIZE: The size to which the root filesystem should be grown.

--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -61,7 +61,7 @@ The options below should be specified as values acceptable to 'lvextend -L':
 ROOT_SIZE: The size to which the root filesystem should be grown.
 
 DATA_SIZE: The desired size for the docker data LV.  Defaults to using
-           98% free space in the VG after the root LV and docker
+           60% free space in the VG after the root LV and docker
            metadata LV have been allocated/grown.
 
            DATA_SIZE can take values acceptable to "lvcreate -L" as

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -28,6 +28,11 @@
 #
 DATA_SIZE=60%FREE
 
+# Controls the chunk size/block size of thin pool. Value of CHUNK_SIZE
+# be suitable to be passed to --chunk-size option of lvconvert.
+#
+CHUNK_SIZE=512K
+
 # Enable resizing partition table backing root volume group. By default it
 # is disabled until and unless GROWPART=true is specified.
 #

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -17,12 +17,16 @@
 #
 # ROOT_SIZE=8G
 
-# The desired size for the docker data LV.  Defaults to using all free space
-# in the VG after the root LV and docker metadata LV have been
-# allocated/grown.
-# Value should be acceptable to -L option of lvextend.
+# The desired size for the docker data LV.  It defaults using 60% of all
+# free space.
 #
-# DATA_SIZE=8G
+# DATA_SIZE can take values acceptable to "lvcreate -L" as well as some
+# values acceptable to to "lvcreate -l". If user intends to pass values
+# acceptable to "lvcreate -l", then only those values which contains "%"
+# in syntax are acceptable.  If value does not contain "%" it is assumed
+# value is suitable for "lvcreate -L".
+#
+DATA_SIZE=60%FREE
 
 # Enable resizing partition table backing root volume group. By default it
 # is disabled until and unless GROWPART=true is specified.

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -1,0 +1,25 @@
+# A quoted, space-separated list of devices to be used.  This currently
+# expects the devices to be unpartitioned drives.  If "VG" is not specified,
+# then use of the root disk's extra space is implied.
+#
+# DEVS=/dev/vdb
+
+# The volume group to use for docker storage.  Defaults to the
+# volume group where the root filesystem resides.  If VG is specified and the
+# volume group does not exist, it will be created (which requires that "DEVS"
+# be nonempty, since we don't currently support putting a second partition on
+# the root disk).
+#
+# VG=
+
+# The size to which the root filesystem should be grown.
+# Value should be acceptable to -L option of lvextend.
+#
+# ROOT_SIZE=8G
+
+# The desired size for the docker data LV.  Defaults to using all free space
+# in the VG after the root LV and docker metadata LV have been
+# allocated/grown.
+# Value should be acceptable to -L option of lvextend.
+#
+# DATA_SIZE=8G

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -23,3 +23,8 @@
 # Value should be acceptable to -L option of lvextend.
 #
 # DATA_SIZE=8G
+
+# Enable resizing partition table backing root volume group. By default it
+# is disabled until and unless GROWPART=true is specified.
+#
+GROWPART=false

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -28,3 +28,12 @@
 # is disabled until and unless GROWPART=true is specified.
 #
 GROWPART=false
+
+# Enable/disable automatic pool extension using lvm
+AUTO_EXTEND_POOL=yes
+
+# Auto pool extension threshold (in % of pool size)
+POOL_AUTOEXTEND_THRESHOLD=60
+
+# Extend the pool by specified percentage when threshold is hit.
+POOL_AUTOEXTEND_PERCENT=20

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -82,8 +82,10 @@ create_metadata_lv() {
   # Calculating the based on actual data size might be better, but is
   # more difficult do to the range of possible inputs.
   VG_SIZE=$( vgs --noheadings --nosuffix --units s -o vg_size $VG )
-  META_SIZE=$(( $VG_SIZE / 1000 + 1 ))
-  if [ ! -n "$META_LV_SIZE" ]; then
+  if [ -n "$VG_SIZE" ]; then
+    META_SIZE=$(( $VG_SIZE / 1000 + 1 ))
+  fi
+  if [ -n "$META_SIZE" ]; then
     lvcreate -L ${META_SIZE}s -n $META_LV_NAME $VG
   fi
 }

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -158,6 +158,8 @@ is_old_data_meta_mode() {
 }
 
 grow_root_pvs() {
+  [ -x "/usr/bin/growpart" ] || return
+
   # Note that growpart is only variable here because we may someday support
   # using separate partitions on the same disk.  Today we fail early in that
   # case.  Also note that the way we are doing this, it should support LVM

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -77,9 +77,10 @@ write_storage_config_file () {
     done )
 
   storage_options="DOCKER_STORAGE_OPTIONS=--storage-opt dm.fs=xfs --storage-opt dm.thinpooldev=$POOL_DEVICE_PATH"
-cat <<EOF > $DOCKER_STORAGE
+cat <<EOF > $DOCKER_STORAGE.tmp
 $storage_options
 EOF
+  mv $DOCKER_STORAGE.tmp $DOCKER_STORAGE
 }
 
 create_metadata_lv() {

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -115,26 +115,10 @@ create_lvm_thin_pool () {
   lvconvert -y --zero n --thinpool $VG/$DATA_LV_NAME --poolmetadata $VG/$META_LV_NAME
 }
 
-# If user specified DATA_SIZE and current pool is smaller, extend it.
-extend_data_lv () {
-  # TODO: Figure out failure cases other than when the requested
-  # size is larger than the current size.  For now, we just let
-  # lvextend fail.
-  if [ -n "$DATA_SIZE" ]; then
-    if [[ $DATA_SIZE == *%* ]]; then
-      lvextend -l $DATA_SIZE $VG/$DATA_LV_NAME || true
-    else
-      lvextend -L $DATA_SIZE $VG/$DATA_LV_NAME || true
-    fi
-  fi
-}
-
 setup_lvm_thin_pool () {
   if ! lvm_pool_exists; then
     create_lvm_thin_pool
     write_storage_config_file
-  else
-    extend_data_lv
   fi
 }
 

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -214,6 +214,12 @@ create_extend_volume_group() {
 }
 
 # Main Script
+if [ -e /usr/lib/docker-storage-setup/docker-storage-setup ]; then
+  source /usr/lib/docker-storage-setup/docker-storage-setup
+fi
+
+# If user has overridden any settings in /etc/sysconfig/docker-storage-setup
+# take that into account.
 if [ -e /etc/sysconfig/docker-storage-setup ]; then
   source /etc/sysconfig/docker-storage-setup
 fi

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -222,7 +222,7 @@ enable_auto_pool_extension() {
   local profileName="${volume_group}--${pool_volume}-extend"
   local profileFile="${profileName}.profile"
   local profileDir
-  local tmpFile=`mktemp tmp.XXXXX`
+  local tmpFile=`mktemp -t tmp.XXXXX`
 
   profileDir=$(lvm dumpconfig | grep "profile_dir" | cut -d "=" -f2 | sed 's/"//g')
   [ -n "$profileDir" ] || return 1

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -160,6 +160,9 @@ is_old_data_meta_mode() {
 grow_root_pvs() {
   [ -x "/usr/bin/growpart" ] || return
 
+  # Grow root pvs only if user asked for it through config file.
+  [ "$GROWPART" != "true" ] && return
+
   # Note that growpart is only variable here because we may someday support
   # using separate partitions on the same disk.  Today we fail early in that
   # case.  Also note that the way we are doing this, it should support LVM

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -76,7 +76,7 @@ write_storage_config_file () {
     fi
     done )
 
-  storage_options="DOCKER_STORAGE_OPTIONS=--storage-opt dm.fs=xfs --storage-opt dm.thinpooldev=$POOL_DEVICE_PATH"
+  storage_options="DOCKER_STORAGE_OPTIONS=-s devicemapper --storage-opt dm.fs=xfs --storage-opt dm.thinpooldev=$POOL_DEVICE_PATH"
 cat <<EOF > $DOCKER_STORAGE.tmp
 $storage_options
 EOF

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -131,6 +131,7 @@ extend_data_lv () {
 setup_lvm_thin_pool () {
   if ! lvm_pool_exists; then
     create_lvm_thin_pool
+    write_storage_config_file
   else
     extend_data_lv
   fi
@@ -274,4 +275,3 @@ fi
 
 # Set up lvm thin pool LV
 setup_lvm_thin_pool
-write_storage_config_file

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -156,7 +156,7 @@ is_old_data_meta_mode() {
 }
 
 grow_root_pvs() {
-  [ -x "/usr/bin/growpart" ] || return
+  [ -x "/usr/bin/growpart" ] || return 0
 
   # Grow root pvs only if user asked for it through config file.
   [ "$GROWPART" != "true" ] && return

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -107,7 +107,10 @@ create_lvm_thin_pool () {
   create_metadata_lv
   create_data_lv
 
-  lvconvert -y --zero n --thinpool $VG/$DATA_LV_NAME --poolmetadata $VG/$META_LV_NAME
+  if [ -n "$CHUNK_SIZE" ]; then
+    CHUNK_SIZE_ARG="-c $CHUNK_SIZE"
+  fi
+  lvconvert -y --zero n $CHUNK_SIZE_ARG --thinpool $VG/$DATA_LV_NAME --poolmetadata $VG/$META_LV_NAME
 }
 
 setup_lvm_thin_pool () {

--- a/docker-storage-setup.spec
+++ b/docker-storage-setup.spec
@@ -12,7 +12,6 @@ Source2:        docker-storage-setup.conf
 BuildRequires:  pkgconfig(systemd)
 
 Requires:       lvm2
-Requires:       cloud-utils-growpart
 Requires:       systemd-units
 Requires:       xfsprogs 
 

--- a/docker-storage-setup.spec
+++ b/docker-storage-setup.spec
@@ -1,3 +1,5 @@
+%define dsslibdir %{_prefix}/lib/docker-storage-setup
+
 Name:           docker-storage-setup
 Version:        0.5
 Release:        1%{?dist}
@@ -29,8 +31,8 @@ install -d %{buildroot}%{_bindir}
 install -p -m 755 %{SOURCE0} %{buildroot}%{_bindir}/docker-storage-setup
 install -d %{buildroot}%{_unitdir}
 install -p -m 644 %{SOURCE1} %{buildroot}%{_unitdir}
-install -d %{buildroot}%{_libdir}/docker-storage-setup/
-install -p -m 644 %{SOURCE2} %{buildroot}%{_libdir}/docker-storage-setup/docker-storage-setup
+install -d %{buildroot}/%{dsslibdir}
+install -p -m 644 %{SOURCE2} %{buildroot}/%{dsslibdir}/docker-storage-setup
 
 %post
 %systemd_post %{name}.service
@@ -44,7 +46,7 @@ install -p -m 644 %{SOURCE2} %{buildroot}%{_libdir}/docker-storage-setup/docker-
 %files
 %{_unitdir}/docker-storage-setup.service
 %{_bindir}/docker-storage-setup
-%{_libdir}/docker-storage-setup/docker-storage-setup
+%{dsslibdir}/docker-storage-setup
 
 %changelog
 * Thu Oct 16 2014 Andy Grimm <agrimm@redhat.com> - 0.0.1-2

--- a/docker-storage-setup.spec
+++ b/docker-storage-setup.spec
@@ -28,8 +28,8 @@ install -d %{buildroot}%{_bindir}
 install -p -m 755 %{SOURCE0} %{buildroot}%{_bindir}/docker-storage-setup
 install -d %{buildroot}%{_unitdir}
 install -p -m 644 %{SOURCE1} %{buildroot}%{_unitdir}
-install -d %{buildroot}%{_sysconfdir}/sysconfig/
-install -p -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/docker-storage-setup
+install -d %{buildroot}%{_libdir}/docker-storage-setup/
+install -p -m 644 %{SOURCE2} %{buildroot}%{_libdir}/docker-storage-setup/docker-storage-setup
 
 %post
 %systemd_post %{name}.service
@@ -43,7 +43,7 @@ install -p -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/docker-storage
 %files
 %{_unitdir}/docker-storage-setup.service
 %{_bindir}/docker-storage-setup
-%config(noreplace) %{_sysconfdir}/sysconfig/docker-storage-setup
+%{_libdir}/docker-storage-setup/docker-storage-setup
 
 %changelog
 * Thu Oct 16 2014 Andy Grimm <agrimm@redhat.com> - 0.0.1-2

--- a/docker-storage-setup.spec
+++ b/docker-storage-setup.spec
@@ -1,6 +1,6 @@
 Name:           docker-storage-setup
-Version:        0.0.1
-Release:        2%{?dist}
+Version:        0.5
+Release:        1%{?dist}
 Summary:        A simple service to setup docker storage devices
 
 License:        ASL 2.0
@@ -16,8 +16,9 @@ Requires:       systemd-units
 Requires:       xfsprogs 
 
 %description
-This is a simple service to divide available storage between
-the OS and docker using LVM devices.
+This is a simple service to configure Docker to use an LVM-managed
+thin pool.  It also supports auto-growing both the pool as well
+as the root logical volume and partition table. 
 
 %prep
 

--- a/docker-storage-setup.spec
+++ b/docker-storage-setup.spec
@@ -7,6 +7,7 @@ License:        ASL 2.0
 URL:            http://github.com/a13m/docker-storage-setup/
 Source0:        docker-storage-setup.sh
 Source1:        docker-storage-setup.service
+Source2:        docker-storage-setup.conf
 
 BuildRequires:  pkgconfig(systemd)
 
@@ -28,8 +29,8 @@ install -d %{buildroot}%{_bindir}
 install -p -m 755 %{SOURCE0} %{buildroot}%{_bindir}/docker-storage-setup
 install -d %{buildroot}%{_unitdir}
 install -p -m 644 %{SOURCE1} %{buildroot}%{_unitdir}
-# install -d %{buildroot}%{_sysconfdir}/sysconfig/
-# install -p -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/docker-storage-setup
+install -d %{buildroot}%{_sysconfdir}/sysconfig/
+install -p -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/docker-storage-setup
 
 %post
 %systemd_post %{name}.service
@@ -43,7 +44,7 @@ install -p -m 644 %{SOURCE1} %{buildroot}%{_unitdir}
 %files
 %{_unitdir}/docker-storage-setup.service
 %{_bindir}/docker-storage-setup
-# %{_sysconfdir}/sysconfig/docker-storage-setup
+%config(noreplace) %{_sysconfdir}/sysconfig/docker-storage-setup
 
 %changelog
 * Thu Oct 16 2014 Andy Grimm <agrimm@redhat.com> - 0.0.1-2


### PR DESCRIPTION
```
docker-storage-setup: Fix typo and condition issues

If 'VG_SIZE' is empty then will hit a shell syntax issue, so it has better to
make sure the 'VG_SIZE' is non-null firstly. In addition, option '-L' of
lvcreate requires an argument to create a logical volume, in here, it
should make sure the 'META_SIZE' not 'META_LV_SIZE' is non-null too.

Signed-off-by: Alex Jia <ajia@redhat.com>
```
